### PR TITLE
Fix for issue #13, plus unit tests

### DIFF
--- a/Expl.Itinerary/Schedule/Primitive/CronSchedule.cs
+++ b/Expl.Itinerary/Schedule/Primitive/CronSchedule.cs
@@ -161,10 +161,17 @@ namespace Expl.Itinerary {
       /// <param name="Month"></param>
       /// <param name="DOW"></param>
       /// <returns></returns>
-      private int ComputeLastDOWOccurance(int Year, int Month, int DOW) {
-         var A = new DateTime(Year, Month, 1).AddDays(DOW);
-         var B = new DateTime(Year, Month + 1, 1).AddDays(-1);
-         return ((int)A.DayOfWeek + B.Day) / 7 - 1;
+      private int ComputeLastDOWOccurance(int Year, int Month, int DOW)
+      {
+          var A = new DateTime(Year, Month, 1);
+          // Determine the first day in the month that occurs in a week which contains the DOW
+          A = (int)A.DayOfWeek <= DOW ? A : A.AddDays(7 - (int)A.DayOfWeek);
+
+          var B = new DateTime(Year, Month, 1).AddMonths(1).AddDays(-1);
+          // Determine the date of the last instace of the DOW
+          B = (int)B.DayOfWeek >= DOW ? B.AddDays(-((int)B.DayOfWeek - DOW)) :
+                                        B.AddDays(-(int)B.DayOfWeek).AddDays(-(7 - DOW));
+          return (B.Day - A.Day) / 7;
       }
 
       /// <summary>

--- a/Itinerary unit tests/ScheduleTests.cs
+++ b/Itinerary unit tests/ScheduleTests.cs
@@ -1750,6 +1750,28 @@ namespace Expl.Itinerary.Test {
                   new TimedEvent(new DateTime(2011, 6, 29, 0, 0, 0), TimeSpan.Zero)
                }
             ),
+            new ScheduleUnitTest("Last Friday of every month",
+            new CronSchedule("0", "0", "*", "*", "FRI#L", TimeSpan.Zero),
+            new DateTime(2012, 1, 1, 0, 0, 0), new DateTime(2012, 6, 1, 0, 0, 0),
+            new TimedEvent[] {
+                new TimedEvent(new DateTime(2012, 1, 27, 0, 0, 0), TimeSpan.Zero),
+                new TimedEvent(new DateTime(2012, 2, 24, 0, 0, 0), TimeSpan.Zero),
+                new TimedEvent(new DateTime(2012, 3, 30, 0, 0, 0), TimeSpan.Zero),
+                new TimedEvent(new DateTime(2012, 4, 27, 0, 0, 0), TimeSpan.Zero),
+                new TimedEvent(new DateTime(2012, 5, 25, 0, 0, 0), TimeSpan.Zero)
+             }
+            ),
+            new ScheduleUnitTest("Last Monday of every month",
+            new CronSchedule("0", "0", "*", "*", "MON#L", TimeSpan.Zero),
+            new DateTime(2012, 1, 1, 0, 0, 0), new DateTime(2012, 6, 1, 0, 0, 0),
+            new TimedEvent[] {
+                new TimedEvent(new DateTime(2012, 1, 30, 0, 0, 0), TimeSpan.Zero),
+                new TimedEvent(new DateTime(2012, 2, 27, 0, 0, 0), TimeSpan.Zero),
+                new TimedEvent(new DateTime(2012, 3, 26, 0, 0, 0), TimeSpan.Zero),
+                new TimedEvent(new DateTime(2012, 4, 30, 0, 0, 0), TimeSpan.Zero),
+                new TimedEvent(new DateTime(2012, 5, 28, 0, 0, 0), TimeSpan.Zero)
+             }
+           ),
             new ScheduleUnitTest("Last Monday - L index syntax",
                new CronSchedule("0", "0", "*", "*", "1#L", TimeSpan.Zero),
                new DateTime(2011, 6, 1, 0, 0, 0), new DateTime(2011, 7, 1, 0, 0, 0),


### PR DESCRIPTION
Fixed Last DOW Occurance Calculation for conditions not caught by the original code:

1) When the first DOW does not occur in the first week of the month
2) When the last DOW does not occur in the last week of the month

Also added additional Unit Tests, as proposed by BennyM.
